### PR TITLE
Added installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,5 @@ Chrome extension that enables the shutdown buttons on WDMyCloud webpages.
 # How to Install
 
 Follow the instructions in the link to load the extension into Chrome.
-[Manually loading extensions into Chrome.](https://developer.chrome.com/extensions/getstarted#unpacked)
+
+[Instructions to manually loading extensions into Chrome.](https://developer.chrome.com/extensions/getstarted#unpacked)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # MyCloudCSSChange
 Chrome extension that enables the shutdown buttons on WDMyCloud webpages.
+
+# How to Install
+
+Follow the instructions in the link to load the extension into Chrome.
+[Manually loading extensions into Chrome.](https://developer.chrome.com/extensions/getstarted#unpacked)


### PR DESCRIPTION
Thought it'd useful to have installation instructions on installing Chrome extensions (not from the Web Store).

Side note: have you thought about putting it on the Web Store? 😄 
